### PR TITLE
maintain es5 compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 5
   },
   "rules": {
     "no-console": 2,

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@ PrettySize
 
 Helper utility to provide pretty printed file sizes (best used for logging or CLI output)
 
-*Note: as of version 1.x this module is now using some ES6+ features, if you are using this in a browser
-you need to transform your code so that this doesn't break.*
-
 Build Status
 ------------
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
 
-const sizes = [
+var sizes = [
     'Bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB'
 ];
 
@@ -18,9 +18,9 @@ Pretty print a size from bytes
 @param {Number} [places=1] Number of decimal places to return
 */
 
-module.exports = (size, nospace, one, places) => {
+module.exports = function (size, nospace, one, places) {
     if (typeof nospace === 'object') {
-        const opts = nospace;
+        var opts = nospace;
         nospace = opts.nospace;
         one = opts.one;
         places = opts.places || 1;
@@ -28,14 +28,17 @@ module.exports = (size, nospace, one, places) => {
         places = places || 1;
     }
 
-    let mysize;
+    var mysize;
 
-    sizes.forEach((unit, id) => {
+    for (var id = 0; id < sizes.length; ++id) {
+        var unit = sizes[id];
+
         if (one) {
             unit = unit.slice(0, 1);
         }
-        const s = Math.pow(1024, id);
-        let fixed;
+
+        var s = Math.pow(1024, id);
+        var fixed;
         if (size >= s) {
             fixed = String((size / s).toFixed(places));
             if (fixed.indexOf('.0') === fixed.length - 2) {
@@ -43,13 +46,13 @@ module.exports = (size, nospace, one, places) => {
             }
             mysize = fixed + (nospace ? '' : ' ') + unit;
         }
-    });
+    }
 
     // zero handling
     // always prints in Bytes
     if (!mysize) {
-        let unit = (one ? sizes[0].slice(0, 1) : sizes[0]);
-        mysize = '0' + (nospace ? '' : ' ') + unit;
+        var _unit = (one ? sizes[0].slice(0, 1) : sizes[0]);
+        mysize = '0' + (nospace ? '' : ' ') + _unit;
     }
 
     return mysize;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prettysize",
   "description": "Convert bytes to other sizes for prettier logging",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "./index.js",
   "devDependencies": {
     "codecov": "^2.3.0",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,121 +1,121 @@
-const assert = require('assert'),
+var assert = require('assert'),
     pretty = require('../index');
 
-describe('prettysize', () => {
+describe('prettysize', function () {
 
-    it('should export a function', () => {
+    it('should export a function', function () {
         assert.ok(pretty);
     });
 
-    it('should print bytes', () => {
+    it('should print bytes', function () {
         assert.equal(pretty(12), '12 Bytes');
     });
 
-    it('should print bytes with no space', () => {
+    it('should print bytes with no space', function () {
         assert.equal(pretty(12, true), '12Bytes');
     });
     
-    it('should print bytes with no space and one char', () => {
+    it('should print bytes with no space and one char', function () {
         assert.equal(pretty(12, true, true), '12B');
     });
 
-    it('should print bytes with space and one char', () => {
+    it('should print bytes with space and one char', function () {
         assert.equal(pretty(12, false, true), '12 B');
     });
     
-    it('should print kilobytes', () => {
+    it('should print kilobytes', function () {
         assert.equal(pretty(123456), '120.6 kB');
     });
     
-    it('should print exact kilobytes', () => {
+    it('should print exact kilobytes', function () {
         assert.equal(pretty(1024), '1 kB');
     });
     
-    it('should print megs', () => {
+    it('should print megs', function () {
         assert.equal(pretty(123456789), '117.7 MB');
     });
     
-    it('should print exact megs', () => {
+    it('should print exact megs', function () {
         assert.equal(pretty(1024 * 1024), '1 MB');
     });
     
-    it('should print gigs', () => {
+    it('should print gigs', function () {
         assert.equal(pretty(12345678901), '11.5 GB');
     });
 
-    it('should print exact gigs', () => {
+    it('should print exact gigs', function () {
         assert.equal(pretty(1024 * 1024 * 1024), '1 GB');
     });
     
-    it('should print teras', () => {
+    it('should print teras', function () {
         assert.equal(pretty(1234567890123), '1.1 TB');
     });
 
-    it('should print exact teras', () => {
+    it('should print exact teras', function () {
         assert.equal(pretty(1024 * 1024 * 1024 * 1024), '1 TB');
     });
     
-    it('should print petas', () => {
+    it('should print petas', function () {
         assert.equal(pretty(1234567890123456), '1.1 PB');
     });
     
-    it('should print exact petas', () => {
+    it('should print exact petas', function () {
         assert.equal(pretty(1024 * 1024 * 1024 * 1024 * 1024), '1 PB');
     });
     
-    it('should print exabyte', () => {
+    it('should print exabyte', function () {
         assert.equal(pretty(1234567890123456789), '1.1 EB');
     });
     
-    it('should print exact exobyte', () => {
+    it('should print exact exobyte', function () {
         assert.equal(pretty(1024 * 1024 * 1024 * 1024 * 1024 * 1024), '1 EB');
     });
 
-    it('should print zero bytes', () => {
+    it('should print zero bytes', function () {
         assert.equal(pretty(0), '0 Bytes');
     });
 
-    it('should print zero bytes with no space', () => {
+    it('should print zero bytes with no space', function () {
         assert.equal(pretty(0, true), '0Bytes');
     });
 
-    it('should print zero bytes with no space [opts]', () => {
+    it('should print zero bytes with no space [opts]', function () {
         assert.equal(pretty(0, {nospace: true}), '0Bytes');
     });
 
-    it('should print zero bytes with no space and one char', () => {
+    it('should print zero bytes with no space and one char', function () {
         assert.equal(pretty(0, true, true), '0B');
     });
 
-    it('should print zero bytes with no space and one char [opts]', () => {
+    it('should print zero bytes with no space and one char [opts]', function () {
         assert.equal(pretty(0, {nospace: true, one: true}), '0B');
     });
 
-    it('should print zero bytes with space and one char', () => {
+    it('should print zero bytes with space and one char', function () {
         assert.equal(pretty(0, false, true), '0 B');
     });
 
-    it('should print zero bytes with space and one char [opts]', () => {
+    it('should print zero bytes with space and one char [opts]', function () {
         assert.equal(pretty(0, {one: true}), '0 B');
     });
 
-    it('should print, two decimal places', () => {
+    it('should print, two decimal places', function () {
         assert.equal(pretty(123456789, false, false, 2), '117.74 MB');
     });
 
-    it('should print, two decimal places [opts]', () => {
+    it('should print, two decimal places [opts]', function () {
         assert.equal(pretty(123456789, {places: 2}), '117.74 MB');
     });
 
-    it('should print three decimal places', () => {
+    it('should print three decimal places', function () {
         assert.equal(pretty(123456789, false, false, 3), '117.738 MB');
     });
 
-    it('should print three decimal places [opts]', () => {
+    it('should print three decimal places [opts]', function () {
         assert.equal(pretty(123456789, {places: 3}), '117.738 MB');
     });
 
-    it('should print three decimal places no space [opts]', () => {
+    it('should print three decimal places no space [opts]', function () {
         assert.equal(pretty(123456789, {nospace: true, places: 3}), '117.738MB');
     });
 


### PR DESCRIPTION
I am using this library in nearly all of my single page web application projects (they are many) as an upload tracker. Since I use javascript only in frontend, I find very valueable to keep ES5 compatibility for a such great project.

Not everyone uses babel (or similiar), even if they do, they do not configure to process the files in node_modules (like I don't).