### PR TITLE
Making String Size optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (size, nospace, one, places,stringOptional) => {
         nospace = opts.nospace;
         one = opts.one;
         places = opts.places || 1;
-        stringOptional = opts.stringOptional || false;
+        stringOptional = opts.stringOptional;
     } else {
         places = places || 1;
     }

--- a/index.js
+++ b/index.js
@@ -18,12 +18,13 @@ Pretty print a size from bytes
 @param {Number} [places=1] Number of decimal places to return
 */
 
-module.exports = (size, nospace, one, places) => {
+module.exports = (size, nospace, one, places,stringOptional) => {
     if (typeof nospace === 'object') {
         const opts = nospace;
         nospace = opts.nospace;
         one = opts.one;
         places = opts.places || 1;
+        stringOptional = opts.stringOptional || false;
     } else {
         places = places || 1;
     }
@@ -51,6 +52,9 @@ module.exports = (size, nospace, one, places) => {
         let unit = (one ? sizes[0].slice(0, 1) : sizes[0]);
         mysize = '0' + (nospace ? '' : ' ') + unit;
     }
-
+    
+    if (stringOptional === true)
+    	return Number.parseFloat(mysize);
+    
     return mysize;
 };


### PR DESCRIPTION
great tiny lib, encounter a situation in my React native project, where I was interested in Conversion Only. thus I thought to purpose the same idea and made the necessary changes that the end result would return conversion only if `{stringOptional: true}` is provided as object. example: 

```
let str = pretty(123456789, {stringOptional: true});
console.log(str); // 117.7

str = pretty(123456789);
console.log(str); //117.7 MB
```
let me know if you will consider this, I will update docs as well.